### PR TITLE
Normalize noun lookup input before matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ The tool uses a two-pronged approach to determine the correct article:
 
 1.  **Lookup Table:** A direct lookup for nouns with fixed, specific rules (e.g., proper nouns like "the USA", abstract concepts like "music", or systems like "the internet"). This provides an instant, accurate answer for common exceptions.
 
+    The lookup step automatically normalizes what you type—trimming extra spaces, ignoring a leading "a/an/the", and removing simple punctuation—so entries such as "the USA" or "an opera" still match the right rule immediately.
+
 2.  **Decision Tree:** For all other nouns, the tool guides the user through a series of contextual questions. By asking about specificity, listener knowledge, and the noun's function (e.g., general concept, institution, classification), it follows a logical path to deduce the correct article based on the rules of English grammar.
 
 Both data sets live in a single machine-readable file, [`rules_data.json`](rules_data.json). The Python logic and the browser UI read from the same source so they always stay in sync.

--- a/index.html
+++ b/index.html
@@ -137,6 +137,23 @@
         // JAVASCRIPT "BRAIN" - CONVERTED FROM rules.py
         // ==============================================================================
 
+        const DETERMINER_PATTERN = /^(?:the|an|a)\s+/i;
+        const SIMPLE_PUNCTUATION_PATTERN = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g;
+
+        // Mirror the Python normalization used for lookup table checks.
+        function normalizeNoun(noun) {
+            if (noun == null) {
+                return "";
+            }
+
+            let normalized = String(noun).trim();
+            normalized = normalized.replace(DETERMINER_PATTERN, "");
+            normalized = normalized.replace(SIMPLE_PUNCTUATION_PATTERN, "");
+            normalized = normalized.replace(/\s+/g, " ").trim();
+
+            return normalized.toLowerCase();
+        }
+
         class ArticleLogic {
             constructor(lookupTable, decisionTree) {
                 this.lookupTable = lookupTable;
@@ -149,7 +166,12 @@
             }
 
             checkLookupTable(noun) {
-                return this.lookupTable[noun.toLowerCase()];
+                const normalized = normalizeNoun(noun);
+                if (!normalized) {
+                    return undefined;
+                }
+
+                return this.lookupTable[normalized];
             }
 
             getCurrentNode() {

--- a/logic.py
+++ b/logic.py
@@ -2,8 +2,25 @@
 # This file contains the "engine" that interacts with the rules.
 # It manages the state of the decision-making process.
 
+# Import standard library helpers
+import re
+import string
+
 # Import the data structures from our rules file
 from rules import LOOKUP_TABLE, DECISION_TREE
+
+
+def _normalize_noun(noun):
+    """Return a canonical form of ``noun`` for lookup-table comparisons."""
+    if noun is None:
+        return ""
+
+    normalized = str(noun).strip()
+    normalized = re.sub(r"^(?:the|an|a)\s+", "", normalized, flags=re.IGNORECASE)
+    normalized = normalized.translate(str.maketrans("", "", string.punctuation))
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+
+    return normalized.lower()
 
 class ArticleLogic:
     """
@@ -22,11 +39,15 @@ class ArticleLogic:
         """
         First check: See if the noun is a special case in our LOOKUP_TABLE.
         Args:
-            noun (str): The user-provided noun, converted to lowercase.
+            noun (str): The raw user-provided noun or phrase.
         Returns:
             dict: The result dictionary if found, otherwise None.
         """
-        return LOOKUP_TABLE.get(noun.lower())
+        normalized = _normalize_noun(noun)
+        if not normalized:
+            return None
+
+        return LOOKUP_TABLE.get(normalized)
 
     def get_current_node(self):
         """
@@ -61,17 +82,22 @@ def test_logic():
     """A simple text-based simulation to ensure our logic works."""
     print("--- Testing ArticleLogic ---")
     
-    # 1. Test the lookup table
+    # 1. Test the lookup table (with normalization for determiners/punctuation)
     print("\n[Test 1: Lookup Table]")
     logic_engine = ArticleLogic()
-    test_noun = "USA"
-    result = logic_engine.check_lookup_table(test_noun)
-    if result:
-        print(f"Checked '{test_noun}': Found in lookup table!")
-        print(f"  -> Article: {result['article']}")
-        print(f"  -> Explanation: {result['explanation']}")
-    else:
-        print(f"Checked '{test_noun}': Not in lookup table. Starting tree...")
+    lookup_samples = [
+        "USA",
+        "the USA",
+        "an opera",
+    ]
+    for sample in lookup_samples:
+        result = logic_engine.check_lookup_table(sample)
+        if result:
+            print(f"Checked '{sample}': Found in lookup table!")
+            print(f"  -> Article: {result['article']}")
+            print(f"  -> Explanation: {result['explanation']}")
+        else:
+            print(f"Checked '{sample}': Not in lookup table. Starting tree...")
 
     # 2. Test the decision tree flow
     print("\n[Test 2: Decision Tree Walkthrough]")
@@ -102,3 +128,4 @@ if __name__ == "__main__":
     # This block runs ONLY when you execute `python logic.py` directly.
     # It allows us to test our logic before building the GUI.
     test_logic()
+


### PR DESCRIPTION
## Summary
- add a shared normalization routine in the Python logic so lookup-table checks trim whitespace, drop leading determiners, strip punctuation, and lowercase nouns
- mirror the same normalization behaviour in the browser logic with a small helper function
- document the lookup normalization and expand manual tests to cover "the USA" and "an opera"

## Testing
- python logic.py

------
https://chatgpt.com/codex/tasks/task_e_68ce51d97604832a9dd8576f5978401a