### PR TITLE
Handle guidance nodes without article recommendations

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,11 @@
 # app.py (Version 4 - With Details)
 
-import customtkinter as ctk
-from logic import ArticleLogic
 from tkinter import messagebox
+
+import customtkinter as ctk
+
+from logic import ArticleLogic
+from rules import GUIDANCE_NODE_TYPE
 
 ctk.set_appearance_mode("System")
 ctk.set_default_color_theme("blue")
@@ -93,15 +96,33 @@ class ArticleApp(ctk.CTk):
         for widget in self.options_frame.winfo_children():
             widget.destroy()
 
-        result_title = f"Recommended Article: '{result_data['article'].upper()}'"
-        result_body = f"{result_data['explanation']}\n\n(Reference: {result_data['rule_ref']})"
-        
+        article_value = result_data.get("article")
+        is_guidance = result_data.get("type") == GUIDANCE_NODE_TYPE or article_value is None
+
+        if is_guidance:
+            result_title = "Guidance Provided (no article recommendation)"
+            body_prefix = "Guidance:\n"
+        else:
+            article_display = str(article_value).upper()
+            result_title = f"Recommended Article: '{article_display}'"
+            body_prefix = ""
+
+        explanation_text = result_data.get("explanation", "")
+        rule_reference = result_data.get("rule_ref")
+        reference_text = f"\n\n(Reference: {rule_reference})" if rule_reference else ""
+        result_body = f"{body_prefix}{explanation_text}{reference_text}"
+
         self.question_label.configure(text=result_title)
-        
+
         # UPDATE: Clear the details label when showing the result
         self.details_label.configure(text="")
 
-        explanation_label = ctk.CTkLabel(self.options_frame, text=result_body, wraplength=500, justify="left")
+        explanation_label = ctk.CTkLabel(
+            self.options_frame,
+            text=result_body,
+            wraplength=500,
+            justify="left",
+        )
         explanation_label.grid(sticky="ew", padx=20, pady=10)
 
         start_over_button = ctk.CTkButton(self.options_frame, text="Start Over", command=self.reset_app)

--- a/index.html
+++ b/index.html
@@ -110,6 +110,15 @@
             font-weight: bold;
             color: var(--secondary-text);
         }
+
+        .explanation-text.guidance {
+            border-left: 4px solid var(--primary-color);
+            background-color: rgba(24, 119, 242, 0.1);
+        }
+
+        .explanation-text.guidance strong {
+            color: var(--primary-color);
+        }
     </style>
 </head>
 <body>
@@ -139,6 +148,7 @@
 
         const DETERMINER_PATTERN = /^(?:the|an|a)\s+/i;
         const SIMPLE_PUNCTUATION_PATTERN = /[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g;
+        const GUIDANCE_NODE_TYPE = "guidance";
 
         // Mirror the Python normalization used for lookup table checks.
         function normalizeNoun(noun) {
@@ -152,6 +162,38 @@
             normalized = normalized.replace(/\s+/g, " ").trim();
 
             return normalized.toLowerCase();
+        }
+
+        function normalizeRulesData(rawData) {
+            if (!rawData || typeof rawData !== "object") {
+                return { lookup_table: {}, decision_tree: {} };
+            }
+
+            const normalized = rawData;
+            const decisionTree = normalized.decision_tree || {};
+
+            Object.values(decisionTree).forEach((node) => {
+                if (!node || typeof node !== "object") {
+                    return;
+                }
+
+                const articleValue = node.article;
+
+                if (node.type === GUIDANCE_NODE_TYPE) {
+                    if (articleValue !== null) {
+                        node.article = null;
+                    }
+                    return;
+                }
+
+                if (typeof articleValue === "string" && articleValue.toUpperCase() === "GUIDANCE") {
+                    node.type = GUIDANCE_NODE_TYPE;
+                    node.article = null;
+                }
+            });
+
+            normalized.decision_tree = decisionTree;
+            return normalized;
         }
 
         class ArticleLogic {
@@ -205,8 +247,9 @@
             detailsLabel.textContent = "Please wait while we fetch the article guide.";
 
             const initializeApp = (data) => {
-                const lookupTable = data.lookup_table;
-                const decisionTree = data.decision_tree;
+                const normalizedData = normalizeRulesData(data);
+                const lookupTable = normalizedData.lookup_table;
+                const decisionTree = normalizedData.decision_tree;
 
                 if (!lookupTable || !decisionTree) {
                     throw new Error('Invalid rules data format.');
@@ -224,13 +267,31 @@
 
                 function displayFinalResult(resultData) {
                     optionsContainer.innerHTML = '';
-                    const articleResult = resultData.article.toUpperCase();
-                    questionLabel.textContent = `Recommended Article: '${articleResult}'`;
+
+                    const articleValue = resultData && resultData.article;
+                    const isGuidance = (resultData && resultData.type === GUIDANCE_NODE_TYPE) || articleValue == null;
+
+                    let headlineText = "Guidance Provided (no article recommendation)";
+                    if (!isGuidance) {
+                        const articleResult = String(articleValue || '').toUpperCase();
+                        headlineText = `Recommended Article: '${articleResult}'`;
+                    }
+
+                    questionLabel.textContent = headlineText;
                     detailsLabel.textContent = "";
 
                     const explanationEl = document.createElement('div');
                     explanationEl.className = 'explanation-text';
-                    explanationEl.innerHTML = `${resultData.explanation}<br><br><span>(Reference: ${resultData.rule_ref})</span>`;
+                    if (isGuidance) {
+                        explanationEl.classList.add('guidance');
+                    }
+
+                    const explanationCopy = (resultData && resultData.explanation) ? resultData.explanation : '';
+                    const ruleRef = (resultData && resultData.rule_ref)
+                        ? `<br><br><span>(Reference: ${resultData.rule_ref})</span>`
+                        : '';
+                    const guidancePrefix = isGuidance ? '<strong>Guidance:</strong> ' : '';
+                    explanationEl.innerHTML = `${guidancePrefix}${explanationCopy}${ruleRef}`;
                     optionsContainer.appendChild(explanationEl);
 
                     const resetButton = document.createElement('button');

--- a/rules.py
+++ b/rules.py
@@ -5,12 +5,41 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+GUIDANCE_NODE_TYPE = "guidance"
+_GUIDANCE_SENTINEL = "GUIDANCE"
+
+
+def _normalize_guidance_nodes(decision_tree):
+    """Ensure guidance-only nodes share a consistent structure."""
+
+    for node in decision_tree.values():
+        if not isinstance(node, dict):
+            continue
+
+        node_type = node.get("type")
+        article_value = node.get("article")
+
+        # If the node is already marked as guidance, force ``article`` to ``None``.
+        if node_type == GUIDANCE_NODE_TYPE:
+            if article_value is not None:
+                node["article"] = None
+            continue
+
+        # Older datasets used a sentinel string in the ``article`` slot. Convert them.
+        if isinstance(article_value, str) and article_value.upper() == _GUIDANCE_SENTINEL:
+            node["type"] = GUIDANCE_NODE_TYPE
+            node["article"] = None
+
+
 _DATA_PATH = Path(__file__).resolve().with_name("rules_data.json")
 
 with _DATA_PATH.open(encoding="utf-8") as data_file:
     _rules_data = json.load(data_file)
 
-LOOKUP_TABLE = _rules_data["lookup_table"]
-DECISION_TREE = _rules_data["decision_tree"]
+decision_tree = _rules_data["decision_tree"]
+_normalize_guidance_nodes(decision_tree)
 
-__all__ = ["LOOKUP_TABLE", "DECISION_TREE"]
+LOOKUP_TABLE = _rules_data["lookup_table"]
+DECISION_TREE = decision_tree
+
+__all__ = ["LOOKUP_TABLE", "DECISION_TREE", "GUIDANCE_NODE_TYPE"]

--- a/rules_data.json
+++ b/rules_data.json
@@ -256,7 +256,8 @@
             }
         },
         "noun_adjunct_rule": {
-            "article": "GUIDANCE",
+            "type": "guidance",
+            "article": null,
             "explanation": "In a noun-noun pair (a noun adjunct), the first noun acts like an adjective. The article you choose depends entirely on the SECOND noun. Please restart the check and focus only on the second noun in your pair.",
             "rule_ref": "7.1"
         },


### PR DESCRIPTION
## Summary
- mark guidance-only decision tree nodes as guidance when loading the rules data and propagate the flag through the shared JSON
- update the web UI to normalize guidance nodes, display guidance messaging without an article headline, and style the guidance note distinctly
- update the desktop app result renderer to branch on the guidance flag and show the new guidance copy

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ce52d190f0832a8164b81392bc154c